### PR TITLE
Fix rights check; fixes #30

### DIFF
--- a/inc/category.class.php
+++ b/inc/category.class.php
@@ -42,6 +42,14 @@ class PluginItilcategorygroupsCategory extends CommonDropdown {
       return __('Link ItilCategory - Groups', 'itilcategorygroups');
    }
 
+   static function canCreate() {
+      return static::canUpdate();
+   }
+
+   static function canPurge() {
+      return static::canUpdate();
+   }
+
    function showForm($id, $options = []) {
 
       if (! $this->can($id, READ)) {


### PR DESCRIPTION
Rights checks are based on `config` right, which has no `CREATE` or `PURGE` value.