### PR TITLE
Fix groups filtering

### DIFF
--- a/ajax/group_values.php
+++ b/ajax/group_values.php
@@ -7,14 +7,19 @@ header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 Session::checkLoginUser();
 
-if (! isset($_REQUEST['itilcategories_id'])) {
-   exit;
+$tickets_id = (int) $_REQUEST['ticket_id'] ?? 0;
+$ticket = new Ticket;
+$ticket->getFromDB($tickets_id);
+
+if (!isset($_REQUEST['itilcategories_id'])) {
+   $_REQUEST['itilcategories_id'] = $ticket->fields['itilcategories_id'];
+}
+if (!isset($_REQUEST['type'])) {
+   $_REQUEST['type'] = $ticket->fields['type'];
 }
 
-$ticket_id = (isset($_REQUEST['ticket_id'])) ? $_REQUEST['ticket_id'] : 0;
-
 $condition = PluginItilcategorygroupsCategory::getSQLCondition(
-   intval($ticket_id),
+   $tickets_id,
    intval($_REQUEST['itilcategories_id']),
    $_REQUEST['type']
 );

--- a/ajax/group_values.php
+++ b/ajax/group_values.php
@@ -13,17 +13,13 @@ if (! isset($_REQUEST['itilcategories_id'])) {
 
 $ticket_id = (isset($_REQUEST['ticket_id'])) ? $_REQUEST['ticket_id'] : 0;
 
-$canApplyFilter = PluginItilcategorygroupsCategory::canApplyFilter(
-   intval($_REQUEST['itilcategories_id'])
-);
-
 $condition = PluginItilcategorygroupsCategory::getSQLCondition(
    intval($ticket_id),
    intval($_REQUEST['itilcategories_id']),
    $_REQUEST['type']
 );
 
-if (! $canApplyFilter || empty($condition)) {
+if (empty($condition)) {
    $condition = [
       'glpi_groups.is_assign' => 1,
    ] + getEntitiesRestrictCriteria("", "entities_id", $_SESSION['glpiactive_entity'], 1);

--- a/scripts/filtergroups.js.php
+++ b/scripts/filtergroups.js.php
@@ -27,14 +27,12 @@ var triggerupdateTicket = function() {
    if (getItilcategories_id() == 0) {
       return;
    } else {
-      setTimeout( function() {
-         $("select[name='_itil_assign[groups_id]']:not(.plugin_redefined)").each(function() {
-            var assign_select_dom_id = $(this).attr('id');
-            var type = $("select[id^='dropdown_type']").val();
+      $("select[name='_itil_assign[groups_id]']:not(.plugin_redefined)").each(function() {
+         var assign_select_dom_id = $(this).attr('id');
+         var type = $("select[id^='dropdown_type']").val();
 
-            redefineDropdown(assign_select_dom_id, groups_url, tickets_id, type);
-         });
-      }, 100);
+         redefineDropdown(assign_select_dom_id, groups_url, tickets_id, type);
+      });
    }
 };
 
@@ -42,7 +40,7 @@ var triggerAll = function() {
    if (tickets_id == 'Not found') {
       triggerNewTicket();
    } else {
-      $(document).ajaxSend(function( event, jqxhr, settings ) {
+      $(document).ajaxComplete(function( event, jqxhr, settings ) {
          if (settings.url.indexOf("dropdownItilActors.php") > 0
             && settings.data.indexOf("group") > 0
                && settings.data.indexOf("assign") > 0

--- a/scripts/filtergroups.js.php
+++ b/scripts/filtergroups.js.php
@@ -28,7 +28,7 @@ var triggerupdateTicket = function() {
       return;
    } else {
       setTimeout( function() {
-         $("select[name='_itil_assign[groups_id]']").each(function() {
+         $("select[name='_itil_assign[groups_id]']:not(.plugin_redefined)").each(function() {
             var assign_select_dom_id = $(this).attr('id');
             var type = $("select[id^='dropdown_type']").val();
 
@@ -58,7 +58,7 @@ var redefineDropdown = function (id, url, tickets_id, type) {
       var templateResult = formatResult;
    }
 
-   $('#' + id).select2({
+   $('#' + id).addClass('plugin_redefined').select2({
       width:                   '80%',
       minimumInputLength:      0,
       quietMillis:             100,

--- a/scripts/filtergroups.js.php
+++ b/scripts/filtergroups.js.php
@@ -27,12 +27,14 @@ var triggerupdateTicket = function() {
    if (getItilcategories_id() == 0) {
       return;
    } else {
-      checkDOMChange("select[name='_itil_assign[groups_id]']", function() {
-         var assign_select_dom_id = $("select[name='_itil_assign[groups_id]']")[0].id;
-         var type = $("select[id^='dropdown_type']").val();
+      setTimeout( function() {
+         $("select[name='_itil_assign[groups_id]']").each(function() {
+            var assign_select_dom_id = $(this).attr('id');
+            var type = $("select[id^='dropdown_type']").val();
 
-         redefineDropdown(assign_select_dom_id, groups_url, tickets_id, type);
-      });
+            redefineDropdown(assign_select_dom_id, groups_url, tickets_id, type);
+         });
+      }, 100);
    }
 };
 
@@ -45,7 +47,7 @@ var triggerAll = function() {
             && settings.data.indexOf("group") > 0
                && settings.data.indexOf("assign") > 0
             ) {
-          triggerupdateTicket();
+            triggerupdateTicket();
          }
       });
    }

--- a/scripts/filtergroups.js.php
+++ b/scripts/filtergroups.js.php
@@ -45,7 +45,9 @@ var triggerAll = function() {
             && settings.data.indexOf("group") > 0
                && settings.data.indexOf("assign") > 0
             ) {
-            triggerupdateTicket();
+            setTimeout(() => {
+               triggerupdateTicket();
+            }, 50);
          }
       });
    }

--- a/scripts/function.js
+++ b/scripts/function.js
@@ -18,13 +18,3 @@ var getUrlParameter = function(val) {
       });
    return result;
 };
-
-
-var checkDOMChange = function (selector, handler) {
-   if ($(selector).get(0)) {
-      return handler();
-   }
-   setTimeout( function() {
-      checkDOMChange(selector, handler);
-   }, 100 );
-};


### PR DESCRIPTION
fix internal !22182

1st commit fix filtering of single action button - add an actor

![image](https://user-images.githubusercontent.com/418844/120800825-af9fdb00-c540-11eb-8704-d3f52a968a9f.png)
When both controls for adding groups was present, only one was altered

second commit restore plugin behavior before #28 was merged.
- option active : display only next level groups
- option disabled: display all groups with levels setup for this categories (<- previous behavior)

After #28, the second point results in a display of all groups (regarding they have a level or not) 

Release when possible (not asap, i'll provide a patch to customer)